### PR TITLE
Fix espresso dependency key

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -68,5 +68,5 @@ dependencies {
     testImplementation testLibraries.mockitoInline
     testImplementation testLibraries.jUnitExt
     testImplementation testLibraries.roboelectric
-    androidTestImplementation testLibraries.esspresso
+    androidTestImplementation testLibraries.espresso
 }

--- a/dependencies/library-versions.gradle
+++ b/dependencies/library-versions.gradle
@@ -48,7 +48,7 @@ ext {
             mockitoCore   : "org.mockito:mockito-core:${mockitoCore}",
             coreTesting   : "androidx.arch.core:core-testing:${archCoreTestingVersion}",
             jUnitExt      : 'androidx.test.ext:junit:1.1.3',
-            esspresso     : 'androidx.test.espresso:espresso-core:3.4.0',
+            espresso      : 'androidx.test.espresso:espresso-core:3.4.0',
             roboelectric  : 'org.robolectric:robolectric:4.4'
     ]
 }


### PR DESCRIPTION
## Summary
- rename `esspresso` library key to `espresso`
- update app module to use `testLibraries.espresso`

## Testing
- `./gradlew clean test` *(fails: gradle wrapper properties file does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6840124b54388326af828cfc212f10f2