### PR TITLE
Fix previousMovies list in repository test

### DIFF
--- a/app/src/test/java/com/example/filmapp/repository/MovieListRepositoryImplTest.kt
+++ b/app/src/test/java/com/example/filmapp/repository/MovieListRepositoryImplTest.kt
@@ -21,6 +21,7 @@ import org.junit.Test
 import org.junit.rules.TestRule
 import org.junit.runner.RunWith
 import org.mockito.MockitoAnnotations
+import org.junit.Assert.assertTrue
 
 @RunWith(AndroidJUnit4::class)
 class MovieListRepositoryImplTest {
@@ -60,8 +61,9 @@ class MovieListRepositoryImplTest {
     @Test
     fun `when service is failed, should return data from local db`() {
         val previousMovies = mutableListOf<MovieModel>().apply {
-            MovieModel(3, "Previous", "asd", "Gan", 5.5, 1)
+            add(MovieModel(3, "Previous", "asd", "Gan", 5.5, 1))
         }
+        assertTrue(previousMovies.isNotEmpty())
         db.movieDAO().insertAll(previousMovies)
 
         whenever(remoteDataSource.getListSingle())


### PR DESCRIPTION
## Summary
- add missing item insertion in `previousMovies`
- check that list is not empty before test continues

## Testing
- `./gradlew clean test` *(fails: Wrapper properties file does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68401254f5a88326b9448218929e7265