### PR TITLE
Fix JUnit capitalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ from [The Movie DB](https://developers.themoviedb.org/4/list/get-list)
 * Volley
 * Room
 * Glide
-* Mockito and jUnit for unit testing
+* Mockito and JUnit for unit testing.
 * Lottie
 
 # Build Instruction


### PR DESCRIPTION
## Summary
- fix JUnit capitalization in README

## Testing
- `./gradlew test` *(fails: gradle-wrapper.properties does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6840125cab84832689dc11427deb00df